### PR TITLE
requirements: jinja2 lt 3.1 for bokeh le 1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ bigfeta
 opencv-contrib-python
 em_stitch
 matplotlib
-jinja2
+jinja2<3.1
 six
 scikit-image
 shapely


### PR DESCRIPTION
jinja2 3.1 breaks bokeh requirement.