### PR TITLE
Fixed close_stack option in make_montage_scapes_stack module

### DIFF
--- a/asap/dataimport/make_montage_scapes_stack.py
+++ b/asap/dataimport/make_montage_scapes_stack.py
@@ -237,7 +237,7 @@ class MakeMontageScapeSectionStack(StackOutputModule):
         # import tilespecs to render
         self.render.run(renderapi.client.import_jsonfiles_parallel,
                         self.output_stack,
-                        jsonfiles)
+                        jsonfiles, close_stack=False)
 
         if self.close_stack:
             # set stack state to complete


### PR DESCRIPTION
Set "close_stack": False in " ./asap/dataimport/make_montage_scapes_stack.py"